### PR TITLE
Make Xamarin Forms based test runner more friendly for UI Tests

### DIFF
--- a/src/xunit.runner.android/AutomationTextCellRenderer.cs
+++ b/src/xunit.runner.android/AutomationTextCellRenderer.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android;
+using Xunit.Runners;
+using Xunit.Runners.Utilities;
+
+[assembly: ExportRenderer(typeof(AutomationTextCell), typeof(AutomationTextCellRenderer))]
+namespace Xunit.Runners
+{
+    public class AutomationTextCellRenderer : TextCellRenderer
+    {
+        protected override Android.Views.View GetCellCore(Cell item, Android.Views.View convertView, Android.Views.ViewGroup parent, Android.Content.Context context)
+        {
+            var view = base.GetCellCore(item, convertView, parent, context);
+            view.ContentDescription = Cell.AutomationId;
+            return view;
+        }
+    }
+}

--- a/src/xunit.runner.android/xunit.runner.android.csproj
+++ b/src/xunit.runner.android/xunit.runner.android.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ResultListener.cs" />
+    <Compile Include="AutomationTextCellRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="NuGet\MainActivity.cs.txt.pp" />

--- a/src/xunit.runner.ios/AutomationTextCellRenderer.cs
+++ b/src/xunit.runner.ios/AutomationTextCellRenderer.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.iOS;
+using Xunit.Runner.iOS;
+using Xunit.Runners.Utilities;
+
+[assembly: ExportRenderer(typeof(AutomationTextCell), typeof(AutomationTextCellRenderer))]
+namespace Xunit.Runner.iOS
+{
+    public class AutomationTextCellRenderer : TextCellRenderer
+    {
+        public AutomationTextCellRenderer()
+        {
+        }
+
+        public override UIKit.UITableViewCell GetCell(Cell item, UIKit.UITableViewCell reusableCell, UIKit.UITableView tv)
+        {
+            var tableViewCell = base.GetCell(item, reusableCell, tv);
+            tableViewCell.AccessibilityIdentifier = item.AutomationId;
+            return tableViewCell;
+        }
+    }
+}

--- a/src/xunit.runner.ios/xunit.runner.ios.csproj
+++ b/src/xunit.runner.ios/xunit.runner.ios.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RunnerAppDelegate.cs" />
     <Compile Include="ThreadPoolHelper.cs" />
+    <Compile Include="AutomationTextCellRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="NuGet\AppDelegate.cs.txt.pp" />

--- a/src/xunit.runner.viewmodels/ViewModels/TestAssemblyViewModel.cs
+++ b/src/xunit.runner.viewmodels/ViewModels/TestAssemblyViewModel.cs
@@ -232,10 +232,12 @@ namespace Xunit.Runners
                 int notRun;
                 results.TryGetValue(TestState.NotRun, out notRun);
 
+                string prefix = notRun == 0 ? "Complete - " : string.Empty;
+
                 // No failures and all run
                 if (failure == 0 && notRun == 0)
                 {
-                    DetailText = $"Success! {positive} test{(positive == 1 ? string.Empty : "s")}";
+                    DetailText = $"{prefix}Success! {positive} test{(positive == 1 ? string.Empty : "s")}";
                     RunStatus = RunStatus.Ok;
 
                     Result = TestState.Passed;
@@ -243,7 +245,7 @@ namespace Xunit.Runners
                 else if (failure > 0 || (notRun > 0 && notRun < count))
                 {
                     // we either have failures or some of the tests are not run
-                    DetailText = $"{positive} success, {failure} failure{(failure > 1 ? "s" : string.Empty)}, {skipped} skip{(skipped > 1 ? "s" : string.Empty)}, {notRun} not run";
+                    DetailText = $"{prefix}{positive} success, {failure} failure{(failure > 1 ? "s" : string.Empty)}, {skipped} skip{(skipped > 1 ? "s" : string.Empty)}, {notRun} not run";
 
                     if (failure > 0) // always show a fail
                     {

--- a/src/xunit.runner.xamarin/Pages/HomePage.xaml.cs
+++ b/src/xunit.runner.xamarin/Pages/HomePage.xaml.cs
@@ -44,6 +44,7 @@ namespace Xunit.Runners.Pages
             // Xam Forms requires us to redraw the table root to add new content
 	        var tr = new TableRoot();
 	        var fs = new TableSection("Test Assemblies");
+	        var i = 0;
 
 	        foreach (var ta in viewModel.TestAssemblies)
 	        {
@@ -51,6 +52,8 @@ namespace Xunit.Runners.Pages
 	            ts.SetBinding(TextCell.TextProperty, "DisplayName");
 	            ts.SetBinding(TextCell.DetailProperty, "DetailText");
 	            ts.SetBinding(TextCell.DetailColorProperty, "RunStatus", converter: AssemblyRunStatusConverter);
+	            ts.AutomationId = $"testAssembly_{i}";
+	            i++;
 
 	            ts.Command = viewModel.NavigateToTestAssemblyCommand;
 	            ts.CommandParameter = ts.BindingContext;
@@ -63,6 +66,7 @@ namespace Xunit.Runners.Pages
 	        {
 	            Text = "Run Everything",
 	            Command = viewModel.RunEverythingCommand,
+                AutomationId = "runEverything"
 	        };
 
 	        table.Root.Skip(1)

--- a/src/xunit.runner.xamarin/Pages/HomePage.xaml.cs
+++ b/src/xunit.runner.xamarin/Pages/HomePage.xaml.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Xamarin.Forms;
+using Xunit.Runners.Utilities;
 
 namespace Xunit.Runners.Pages
 {
@@ -48,7 +49,7 @@ namespace Xunit.Runners.Pages
 
 	        foreach (var ta in viewModel.TestAssemblies)
 	        {
-	            var ts = new TextCell {BindingContext = ta};
+	            var ts = new AutomationTextCell {BindingContext = ta};
 	            ts.SetBinding(TextCell.TextProperty, "DisplayName");
 	            ts.SetBinding(TextCell.DetailProperty, "DetailText");
 	            ts.SetBinding(TextCell.DetailColorProperty, "RunStatus", converter: AssemblyRunStatusConverter);
@@ -62,7 +63,7 @@ namespace Xunit.Runners.Pages
 	        }
 	        tr.Add(fs); // add the first section
 
-	        var run = new TextCell
+	        var run = new AutomationTextCell
 	        {
 	            Text = "Run Everything",
 	            Command = viewModel.RunEverythingCommand,
@@ -75,7 +76,6 @@ namespace Xunit.Runners.Pages
 	        tr.Add(table.Root.Skip(1)); // Skip the first section and add the others
 
 	        table.Root = tr;
-
 	    }
 	}
 }

--- a/src/xunit.runner.xamarin/Utilities/AutomationTextCell.cs
+++ b/src/xunit.runner.xamarin/Utilities/AutomationTextCell.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Xamarin.Forms;
+
+namespace Xunit.Runners.Utilities
+{
+    public class AutomationTextCell : TextCell
+    {
+        public AutomationTextCell()
+        {
+        }
+    }
+}

--- a/src/xunit.runner.xamarin/xunit.runner.viewmodels.projitems
+++ b/src/xunit.runner.xamarin/xunit.runner.viewmodels.projitems
@@ -46,5 +46,6 @@
       <DependentUpon>TestResultPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\Commands.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\AutomationTextCell.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR does two things:
- Adds unique AutomationIds to the main page for each individual test run and the Run All button. Since Xamarin Forms does not handle automation Ids on TextCells (or any cells) a custom renderer needed to be added. The AutomationIds are currently only setup for Android and iOS use.
- Adds a "Completed -" prefix message to the test run output. This can be watched for by UI Tests so they can wait until all the test actually are complete.