### PR TITLE
Improves the ability to customize the report output

### DIFF
--- a/src/xunit.runner.devices/Platforms/Forms/FormsRunner.cs
+++ b/src/xunit.runner.devices/Platforms/Forms/FormsRunner.cs
@@ -15,14 +15,17 @@ namespace Xunit.Runners
         // ReSharper disable once NotAccessedField.Local
         readonly Assembly executionAssembly;
         readonly IReadOnlyCollection<Assembly> testAssemblies;
-        readonly TextWriter writer;
+        readonly IResultChannel resultChannel;
 
-        public FormsRunner(Assembly executionAssembly, IReadOnlyCollection<Assembly> testAssemblies, TextWriter writer)
+        public FormsRunner(Assembly executionAssembly, IReadOnlyCollection<Assembly> testAssemblies, TextWriter writer) : this(executionAssembly, testAssemblies, new ResultListener(writer))
+        {
+        }
+
+        public FormsRunner(Assembly executionAssembly, IReadOnlyCollection<Assembly> testAssemblies, IResultChannel resultChannel)
         {
             this.executionAssembly = executionAssembly;
             this.testAssemblies = testAssemblies;
-            this.writer = writer;
-
+            this.resultChannel = resultChannel;
 
             MainPage = GetMainPage();
         }
@@ -33,7 +36,7 @@ namespace Xunit.Runners
             var hp = new HomePage();
             var nav = new Navigator(hp.Navigation);
 
-            var runner = new DeviceRunner(testAssemblies, nav, new ResultListener(writer));
+            var runner = new DeviceRunner(testAssemblies, nav, resultChannel);
 
             var vm = new HomeViewModel(nav, runner);
 

--- a/src/xunit.runner.devices/Platforms/android/Activities/RunnerActivity.cs
+++ b/src/xunit.runner.devices/Platforms/android/Activities/RunnerActivity.cs
@@ -21,7 +21,9 @@ namespace Xunit.Runners.UI
         protected bool Initialized { get; private set; }
 
         protected bool TerminateAfterExecution { get; set; }
+        [Obsolete("Use ResultChannel")]
         protected TextWriter Writer { get; set; }
+        protected IResultChannel ResultChannel { get; set; }
         protected bool AutoStart { get; set; }
 
         protected override void OnCreate(Bundle bundle)
@@ -35,7 +37,7 @@ namespace Xunit.Runners.UI
             RunnerOptions.Current.TerminateAfterExecution = TerminateAfterExecution;
             RunnerOptions.Current.AutoStart = AutoStart;
 
-            runner = new FormsRunner(executionAssembly, testAssemblies, Writer);
+            runner = new FormsRunner(executionAssembly, testAssemblies, ResultChannel ?? new ResultListener(Writer));
 
             Initialized = true;
 

--- a/src/xunit.runner.devices/Platforms/ios/RunnerAppDelegate.cs
+++ b/src/xunit.runner.devices/Platforms/ios/RunnerAppDelegate.cs
@@ -32,7 +32,9 @@ namespace Xunit.Runner
         protected bool Initialized { get; set; }
 
         protected bool TerminateAfterExecution { get; set; }
+        [Obsolete("Use ResultChannel")]
         protected TextWriter Writer { get; set; }
+        protected IResultChannel ResultChannel { get; set; }
 
         //
         // This method is invoked when the application has loaded and is ready to run. In this 
@@ -48,7 +50,7 @@ namespace Xunit.Runner
             RunnerOptions.Current.TerminateAfterExecution = TerminateAfterExecution;
             RunnerOptions.Current.AutoStart = AutoStart;
 
-            runner = new FormsRunner(executionAssembly, testAssemblies, Writer);
+            runner = new FormsRunner(executionAssembly, testAssemblies, ResultChannel ?? new ResultListener(Writer));
 
             Initialized = true;
 


### PR DESCRIPTION
With this change, I was much more able to control the test output, logging directly to a sql server database, or customize the output to write out a TRX report instead.

Here's an example of a TRX channel:

```cs
    public class TrxResultChannel : Xunit.Runners.IResultChannel
    {
        private string path;
        private XmlDocument _doc;
        private int testCount;
        private int testFailed;
        private int testSucceeded;

        private XmlElement _rootNode;
        private XmlElement _resultsNode;
        private XmlElement _testDefinitions;
        private XmlElement _header;

        public TrxResultChannel(string path)
        {
            this.path = path;
        }

        public Task CloseChannel()
        {
            _header.SetAttribute("finish", DateTime.Now.ToString("O"));

            var resultSummary = _doc.CreateElement("_resultSummary");
            resultSummary.SetAttribute("outcome", "Passed");
            resultSummary.SetAttribute("passed", testSucceeded.ToString());
            resultSummary.SetAttribute("failed", testFailed.ToString());
            resultSummary.SetAttribute("total", testCount.ToString());;
            _rootNode.AppendChild(resultSummary);
            _doc.Save(path);
            return Task.CompletedTask;
        }

        public Task<bool> OpenChannel(string message = null)
        {
            testCount = testFailed = testSucceeded = 0;
            _doc = new XmlDocument();
            _rootNode = _doc.CreateElement("TestRun");
            _rootNode.SetAttribute("id", Guid.NewGuid().ToString());
            _doc.AppendChild(_rootNode);
            _header = _doc.CreateElement("Times");
            _header.SetAttribute("finish", DateTime.Now.ToString("O"));
            _header.SetAttribute("start", DateTime.Now.ToString("O"));
            _header.SetAttribute("creation", DateTime.Now.ToString("O"));
            _rootNode.AppendChild(_header);

            _resultsNode = _doc.CreateElement("Results");
            _rootNode.AppendChild(_resultsNode);
            _testDefinitions = _doc.CreateElement("TestDefinitions");
            _rootNode.AppendChild(_testDefinitions);
            return Task.FromResult(true);
        }

        public void RecordResult(TestResultViewModel result)
        {
            string id = Guid.NewGuid().ToString();
            var resultNode = _doc.CreateElement("UnitTestResult");
            resultNode.SetAttribute("outcome", result.TestCase.Result.ToString());
            resultNode.SetAttribute("testName", result.TestCase.DisplayName);
            resultNode.SetAttribute("testId", id);
            resultNode.SetAttribute("duration", result.Duration.ToString());

            if (result.TestCase.Result == TestState.Failed)
            {
                testFailed++;
                var output = _doc.CreateElement("Output");
                var errorInfo = _doc.CreateElement("ErrorInfo");
                var message = _doc.CreateElement("Message");
                message.InnerText = result.ErrorMessage;
                var stackTrace = _doc.CreateElement("StackTrace");
                stackTrace.InnerText = result.ErrorStackTrace;
                output.AppendChild(errorInfo);
                errorInfo.AppendChild(message);
                errorInfo.AppendChild(stackTrace);
                resultNode.AppendChild(output);
            }
            else
            {
                testSucceeded++;
            }
            testCount++;

            _resultsNode.AppendChild(resultNode);

            var testNode = _doc.CreateElement("UnitTest");
            testNode.SetAttribute("name", result.TestCase.DisplayName);
            testNode.SetAttribute("id", id);
            var testMethodName = _doc.CreateElement("TestMethod");
            testMethodName.SetAttribute("name", result.TestCase.DisplayName);
            testMethodName.SetAttribute("className", result.TestCase.DisplayName);
            testNode.AppendChild(testMethodName);
            _testDefinitions.AppendChild(testNode);            
        }
    }
```