### PR TITLE
Fixed generated TRX file not opening in Visual Studio

### DIFF
--- a/src/xunit.runner.devices/ResultChannels/TrxResultChannel.cs
+++ b/src/xunit.runner.devices/ResultChannels/TrxResultChannel.cs
@@ -17,6 +17,7 @@ namespace Xunit.Runners.ResultChannels
         private const string testListId = "8c84fa94-04c1-424b-9868-57a2d4851a1d";
         private System.IO.Stream outputStream;
         private readonly bool disposeStream;
+        private readonly object lockObj = new object();
         private XmlDocument doc;
         private int testCount;
         private int testFailed;
@@ -108,155 +109,165 @@ namespace Xunit.Runners.ResultChannels
 
         Task<bool> IResultChannel.OpenChannel(string message)
         {
-            testCount = testFailed = testSucceeded = 0;
-            doc = new XmlDocument();
-            rootNode = doc.CreateElement("TestRun", xmlNamespace);
-            rootNode.SetAttribute("id", Guid.NewGuid().ToString());
-            rootNode.SetAttribute("name", TestRunName);
-            rootNode.SetAttribute("runUser", TestRunUser);
-            doc.AppendChild(rootNode);
-            header = doc.CreateElement("Times", xmlNamespace);
-            header.SetAttribute("finish", DateTime.Now.ToString("O", CultureInfo.InvariantCulture));
-            header.SetAttribute("start", DateTime.Now.ToString("O", CultureInfo.InvariantCulture));
-            header.SetAttribute("creation", DateTime.Now.ToString("O", CultureInfo.InvariantCulture));
-            rootNode.AppendChild(header);
-            resultsNode = doc.CreateElement("Results", xmlNamespace);
-            rootNode.AppendChild(resultsNode);
-            testDefinitions = doc.CreateElement("TestDefinitions", xmlNamespace);
-            rootNode.AppendChild(testDefinitions);
-            testEntries = doc.CreateElement("TestEntries", xmlNamespace);
-            rootNode.AppendChild(testEntries);
-            var testLists = doc.CreateElement("TestLists", xmlNamespace);
-            var testList = doc.CreateElement("TestList", xmlNamespace);
-            testList.SetAttribute("name", "Results Not in a List");
-            testList.SetAttribute("id", testListId);
-            testLists.AppendChild(testList);
-            rootNode.AppendChild(testLists);
-            return Task.FromResult(true);
+            lock (lockObj)
+            {
+                testCount = testFailed = testSucceeded = 0;
+                doc = new XmlDocument();
+                rootNode = doc.CreateElement("TestRun", xmlNamespace);
+                rootNode.SetAttribute("id", Guid.NewGuid().ToString());
+                rootNode.SetAttribute("name", TestRunName);
+                rootNode.SetAttribute("runUser", TestRunUser);
+                doc.AppendChild(rootNode);
+                header = doc.CreateElement("Times", xmlNamespace);
+                header.SetAttribute("finish", DateTime.Now.ToString("O", CultureInfo.InvariantCulture));
+                header.SetAttribute("start", DateTime.Now.ToString("O", CultureInfo.InvariantCulture));
+                header.SetAttribute("creation", DateTime.Now.ToString("O", CultureInfo.InvariantCulture));
+                rootNode.AppendChild(header);
+                resultsNode = doc.CreateElement("Results", xmlNamespace);
+                rootNode.AppendChild(resultsNode);
+                testDefinitions = doc.CreateElement("TestDefinitions", xmlNamespace);
+                rootNode.AppendChild(testDefinitions);
+                testEntries = doc.CreateElement("TestEntries", xmlNamespace);
+                rootNode.AppendChild(testEntries);
+                var testLists = doc.CreateElement("TestLists", xmlNamespace);
+                var testList = doc.CreateElement("TestList", xmlNamespace);
+                testList.SetAttribute("name", "Results Not in a List");
+                testList.SetAttribute("id", testListId);
+                testLists.AppendChild(testList);
+                rootNode.AppendChild(testLists);
+                return Task.FromResult(true);
+            }
         }
 
         void ITestListener.RecordResult(TestResultViewModel result)
         {
             var id = Guid.NewGuid().ToString();
             var executionId = Guid.NewGuid().ToString();
-            var resultNode = doc.CreateElement("UnitTestResult", xmlNamespace);
-            resultNode.SetAttribute("outcome", ToTrxStatus(result.TestCase.Result));
-            resultNode.SetAttribute("testType", "13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b");
-            resultNode.SetAttribute("testListId", testListId);
-            resultNode.SetAttribute("executionId", executionId);
-            var idx = result.TestCase.DisplayName.LastIndexOf('.');
-            var testName = result.TestCase.TestCase.TestMethod.Method.Name;
-            var className = result.TestCase.TestCase.TestMethod.TestClass.Class.Name;
-            resultNode.SetAttribute("testName", testName);
-            resultNode.SetAttribute("testId", id);
-            resultNode.SetAttribute("duration", result.Duration.ToString("c", CultureInfo.InvariantCulture));
-            resultNode.SetAttribute("computerName", "");
 
-            if (result.TestCase.Result == TestState.Failed)
+            lock (lockObj)
             {
-                testFailed++;
-                var output = doc.CreateElement("Output", xmlNamespace);
-                var errorInfo = doc.CreateElement("ErrorInfo", xmlNamespace);
-                var message = doc.CreateElement("Message", xmlNamespace);
-                message.InnerText = result.ErrorMessage;
-                var stackTrace = doc.CreateElement("StackTrace", xmlNamespace);
-                stackTrace.InnerText = result.ErrorStackTrace;
-                output.AppendChild(errorInfo);
-                errorInfo.AppendChild(message);
-                errorInfo.AppendChild(stackTrace);
-                resultNode.AppendChild(output);
-            }
-            else
-            {
-                testSucceeded++;
-            }
-            testCount++;
+                var resultNode = doc.CreateElement("UnitTestResult", xmlNamespace);
+                resultNode.SetAttribute("outcome", ToTrxStatus(result.TestCase.Result));
+                resultNode.SetAttribute("testType", "13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b");
+                resultNode.SetAttribute("testListId", testListId);
+                resultNode.SetAttribute("executionId", executionId);
+                var idx = result.TestCase.DisplayName.LastIndexOf('.');
+                var testName = result.TestCase.TestCase.TestMethod.Method.Name;
+                var className = result.TestCase.TestCase.TestMethod.TestClass.Class.Name;
+                resultNode.SetAttribute("testName", testName);
+                resultNode.SetAttribute("testId", id);
+                resultNode.SetAttribute("duration", result.Duration.ToString("c", CultureInfo.InvariantCulture));
+                resultNode.SetAttribute("computerName", "");
 
-            resultsNode.AppendChild(resultNode);
-
-            var testNode = doc.CreateElement("UnitTest", xmlNamespace);
-            testNode.SetAttribute("name", testName);
-            testNode.SetAttribute("id", id);
-            testNode.SetAttribute("storage", result.TestCase.AssemblyFileName);
-            XmlElement properties = null;
-            List<string> categories = null;
-            foreach (var prop in result.TestCase.TestCase.Traits)
-            {
-                if (prop.Key == CategoryTraitName)
+                if (result.TestCase.Result == TestState.Failed)
                 {
-                    categories = prop.Value;
-                    continue;
+                    testFailed++;
+                    var output = doc.CreateElement("Output", xmlNamespace);
+                    var errorInfo = doc.CreateElement("ErrorInfo", xmlNamespace);
+                    var message = doc.CreateElement("Message", xmlNamespace);
+                    message.InnerText = result.ErrorMessage;
+                    var stackTrace = doc.CreateElement("StackTrace", xmlNamespace);
+                    stackTrace.InnerText = result.ErrorStackTrace;
+                    output.AppendChild(errorInfo);
+                    errorInfo.AppendChild(message);
+                    errorInfo.AppendChild(stackTrace);
+                    resultNode.AppendChild(output);
                 }
-                foreach (var v in prop.Value)
+                else
                 {
-                    if (properties == null)
+                    testSucceeded++;
+                }
+                testCount++;
+
+                resultsNode.AppendChild(resultNode);
+
+                var testNode = doc.CreateElement("UnitTest", xmlNamespace);
+                testNode.SetAttribute("name", testName);
+                testNode.SetAttribute("id", id);
+                testNode.SetAttribute("storage", result.TestCase.AssemblyFileName);
+                XmlElement properties = null;
+                List<string> categories = null;
+                foreach (var prop in result.TestCase.TestCase.Traits)
+                {
+                    if (prop.Key == CategoryTraitName)
                     {
-                        properties = doc.CreateElement("Properties", xmlNamespace);
-                        testNode.AppendChild(properties);
+                        categories = prop.Value;
+                        continue;
                     }
+                    foreach (var v in prop.Value)
+                    {
+                        if (properties == null)
+                        {
+                            properties = doc.CreateElement("Properties", xmlNamespace);
+                            testNode.AppendChild(properties);
+                        }
 
-                    var property = doc.CreateElement("Property", xmlNamespace);
-                    var key = doc.CreateElement("Key", xmlNamespace);
-                    key.InnerText = prop.Key;
-                    property.AppendChild(key);
-                    var value = doc.CreateElement("Value", xmlNamespace);
-                    value.InnerText = v;
-                    property.AppendChild(value);
-                    properties.AppendChild(property);
+                        var property = doc.CreateElement("Property", xmlNamespace);
+                        var key = doc.CreateElement("Key", xmlNamespace);
+                        key.InnerText = prop.Key;
+                        property.AppendChild(key);
+                        var value = doc.CreateElement("Value", xmlNamespace);
+                        value.InnerText = v;
+                        property.AppendChild(value);
+                        properties.AppendChild(property);
+                    }
                 }
-            }
 
-            if (categories != null && categories.Any())
-            {
-                var testCategory = doc.CreateElement("TestCategory", xmlNamespace);
-                foreach (var category in categories)
+                if (categories != null && categories.Any())
                 {
-                    var item = doc.CreateElement("TestCategoryItem", xmlNamespace);
-                    item.SetAttribute("TestCategory", category);
-                    testCategory.AppendChild(item);
+                    var testCategory = doc.CreateElement("TestCategory", xmlNamespace);
+                    foreach (var category in categories)
+                    {
+                        var item = doc.CreateElement("TestCategoryItem", xmlNamespace);
+                        item.SetAttribute("TestCategory", category);
+                        testCategory.AppendChild(item);
+                    }
+                    testNode.AppendChild(testCategory);
                 }
-                testNode.AppendChild(testCategory);
+                var execution = doc.CreateElement("Execution", xmlNamespace);
+                execution.SetAttribute("id", executionId);
+                testNode.AppendChild(execution);
+                var testMethodName = doc.CreateElement("TestMethod", xmlNamespace);
+                testMethodName.SetAttribute("name", testName);
+                testMethodName.SetAttribute("className", className);
+                testMethodName.SetAttribute("codeBase", result.TestCase.AssemblyFileName);
+                testNode.AppendChild(testMethodName);
+
+                testDefinitions.AppendChild(testNode);
+
+                var testEntry = doc.CreateElement("TestEntry", xmlNamespace);
+                testEntry.SetAttribute("testListId", testListId);
+                testEntry.SetAttribute("testId", id);
+                testEntry.SetAttribute("executionId", executionId);
+                testEntries.AppendChild(testEntry);
             }
-            var execution = doc.CreateElement("Execution", xmlNamespace);
-            execution.SetAttribute("id", executionId);
-            testNode.AppendChild(execution);
-            var testMethodName = doc.CreateElement("TestMethod", xmlNamespace);
-            testMethodName.SetAttribute("name", testName);
-            testMethodName.SetAttribute("className", className);
-            testMethodName.SetAttribute("codeBase", result.TestCase.AssemblyFileName);
-            testNode.AppendChild(testMethodName);
-
-            testDefinitions.AppendChild(testNode);
-
-            var testEntry = doc.CreateElement("TestEntry", xmlNamespace);
-            testEntry.SetAttribute("testListId", testListId);
-            testEntry.SetAttribute("testId", id);
-            testEntry.SetAttribute("executionId", executionId);
-            testEntries.AppendChild(testEntry);
         }
 
         Task IResultChannel.CloseChannel()
         {
-            header.SetAttribute("finish", DateTime.Now.ToString("O"));
-            var resultSummary = doc.CreateElement("ResultSummary", xmlNamespace);
-            resultSummary.SetAttribute("outcome", "Completed");
-            var counters = doc.CreateElement("Counters", xmlNamespace);
-            counters.SetAttribute("passed", testSucceeded.ToString(CultureInfo.InvariantCulture));
-            counters.SetAttribute("failed", testFailed.ToString(CultureInfo.InvariantCulture));
-            counters.SetAttribute("total", testCount.ToString(CultureInfo.InvariantCulture));
-            resultSummary.AppendChild(counters);
-            rootNode.AppendChild(resultSummary);
-            doc.Save(outputStream);
-            if (disposeStream)
+            lock (lockObj)
             {
-                outputStream.Dispose();
-            }
+                header.SetAttribute("finish", DateTime.Now.ToString("O"));
+                var resultSummary = doc.CreateElement("ResultSummary", xmlNamespace);
+                resultSummary.SetAttribute("outcome", "Completed");
+                var counters = doc.CreateElement("Counters", xmlNamespace);
+                counters.SetAttribute("passed", testSucceeded.ToString(CultureInfo.InvariantCulture));
+                counters.SetAttribute("failed", testFailed.ToString(CultureInfo.InvariantCulture));
+                counters.SetAttribute("total", testCount.ToString(CultureInfo.InvariantCulture));
+                resultSummary.AppendChild(counters);
+                rootNode.AppendChild(resultSummary);
+                doc.Save(outputStream);
+                if (disposeStream)
+                {
+                    outputStream.Dispose();
+                }
 
 #if __IOS__ || MAC
-            if (showNetworkIndicator)
-                UIKit.UIApplication.SharedApplication.NetworkActivityIndicatorVisible = false;
+                if (showNetworkIndicator)
+                    UIKit.UIApplication.SharedApplication.NetworkActivityIndicatorVisible = false;
 #endif
-            return Task.CompletedTask;
+                return Task.CompletedTask;
+            }
         }
 
         private static string ToTrxStatus(TestState result)

--- a/src/xunit.runner.devices/ResultChannels/TrxResultChannel.cs
+++ b/src/xunit.runner.devices/ResultChannels/TrxResultChannel.cs
@@ -149,7 +149,7 @@ namespace Xunit.Runners.ResultChannels
             var className = result.TestCase.TestCase.TestMethod.TestClass.Class.Name;
             resultNode.SetAttribute("testName", testName);
             resultNode.SetAttribute("testId", id);
-            resultNode.SetAttribute("duration", result.Duration.ToString("G", CultureInfo.InvariantCulture));
+            resultNode.SetAttribute("duration", result.Duration.ToString("c", CultureInfo.InvariantCulture));
             resultNode.SetAttribute("computerName", "");
 
             if (result.TestCase.Result == TestState.Failed)


### PR DESCRIPTION
The generated XML document cannot be opened in Visual Studio because the "duration" attribute format is invalid.
Also, the TeamCity TRX reporter generates warnings for the same reason (ex: Failed to parse duration from duration attribute '0:00:00:00.1260000'. 0ms is chosen).
This PR fixes it.